### PR TITLE
chore: migrate to workload contract

### DIFF
--- a/Chart.lock
+++ b/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: lib-chart
   repository: oci://ghcr.io/orhayoun-eevee
-  version: 0.0.11
-digest: sha256:de6d600ff7a89a6bdf0ef9c50501f4a3ccb3dc7712f60e43b278f4c66b147287
-generated: "2026-03-04T18:33:00.354291903Z"
+  version: 0.0.14
+digest: sha256:b8d546a88d3e61c4673866ba0ac71fef0aff5310c416a0b8a5958b252de98289
+generated: "2026-05-03T15:45:30.94159+03:00"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: transmission
 description: A Helm chart for Transmission using lib-chart
 type: application
-version: 0.0.8
+version: 0.0.9
 appVersion: "4.0.6"
 keywords:
   - transmission
@@ -10,7 +10,7 @@ keywords:
   - bittorrent
 dependencies:
   - name: lib-chart
-    version: "0.0.11"
+    version: "0.0.14"
     repository: "oci://ghcr.io/orhayoun-eevee"
 maintainers:
   - name: Transmission Team

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Transmission Helm Chart
 
-This chart deploys Transmission using the shared dependency `lib-chart` (`0.0.7`).
+This chart deploys Transmission using the shared dependency `lib-chart` (`0.0.14`).
 
 ## Installation
 
@@ -10,7 +10,7 @@ helm install transmission . --namespace download-clients
 
 ## Dependencies
 
-- `lib-chart` (`0.0.7`) from `oci://ghcr.io/orhayoun-eevee`
+- `lib-chart` (`0.0.14`) from `oci://ghcr.io/orhayoun-eevee`
 
 Update dependencies from chart root:
 

--- a/tests/scenarios/overrides.yaml
+++ b/tests/scenarios/overrides.yaml
@@ -12,11 +12,12 @@ network:
           metrics:
             port: 9200
 
-deployment:
-  replicas: 2
-  podSecurityContext:
-    fsGroup: 2000
-  containers:
-    transmission:
-      securityContext:
-        runAsUser: 2001
+workload:
+  spec:
+    replicas: 2
+    podSecurityContext:
+      fsGroup: 2000
+    containers:
+      transmission:
+        securityContext:
+          runAsUser: 2001

--- a/tests/snapshots/full.yaml
+++ b/tests/snapshots/full.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: transmission
     app.kubernetes.io/version: 4.0.6
-    helm.sh/chart: transmission-0.0.8
+    helm.sh/chart: transmission-0.0.9
 spec:
   podSelector:
     matchLabels:
@@ -99,7 +99,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: transmission
     app.kubernetes.io/version: 4.0.6
-    helm.sh/chart: transmission-0.0.8
+    helm.sh/chart: transmission-0.0.9
   annotations:
     app.kubernetes.io/managed-by: argocd
     description: Transmission media center service account
@@ -117,7 +117,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: transmission
     app.kubernetes.io/version: 4.0.6
-    helm.sh/chart: transmission-0.0.8
+    helm.sh/chart: transmission-0.0.9
   annotations:
     helm.sh/resource-policy: keep
 spec:
@@ -140,7 +140,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: transmission
     app.kubernetes.io/version: 4.0.6
-    helm.sh/chart: transmission-0.0.8
+    helm.sh/chart: transmission-0.0.9
   annotations:
     description: Transmission HTTP service
 spec:
@@ -166,7 +166,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: transmission
     app.kubernetes.io/version: 4.0.6
-    helm.sh/chart: transmission-0.0.8
+    helm.sh/chart: transmission-0.0.9
   annotations:
     description: Transmission metrics service
 spec:
@@ -192,7 +192,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: transmission
     app.kubernetes.io/version: 4.0.6
-    helm.sh/chart: transmission-0.0.8
+    helm.sh/chart: transmission-0.0.9
 spec:
   replicas: 1
   revisionHistoryLimit: 3
@@ -210,11 +210,12 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: transmission
         app.kubernetes.io/version: 4.0.6
-        helm.sh/chart: transmission-0.0.8
+        helm.sh/chart: transmission-0.0.9
         app.kubernetes.io/part-of: download-clients
         logging.kubernetes.io/component: download-clients
         logging.kubernetes.io/service: transmission
     spec:
+      
       terminationGracePeriodSeconds: 60
       securityContext:
         fsGroup: 1010
@@ -434,7 +435,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: transmission
     app.kubernetes.io/version: 4.0.6
-    helm.sh/chart: transmission-0.0.8
+    helm.sh/chart: transmission-0.0.9
 spec:
   selector:
     matchLabels:
@@ -463,7 +464,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: transmission
     app.kubernetes.io/version: 4.0.6
-    helm.sh/chart: transmission-0.0.8
+    helm.sh/chart: transmission-0.0.9
 spec:
   selector:
     matchLabels:
@@ -492,7 +493,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: transmission
     app.kubernetes.io/version: 4.0.6
-    helm.sh/chart: transmission-0.0.8
+    helm.sh/chart: transmission-0.0.9
 spec:
   selector:
     matchLabels:
@@ -522,7 +523,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: transmission
     app.kubernetes.io/version: 4.0.6
-    helm.sh/chart: transmission-0.0.8
+    helm.sh/chart: transmission-0.0.9
 spec:
   selector:
     matchLabels:
@@ -551,7 +552,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: transmission
     app.kubernetes.io/version: 4.0.6
-    helm.sh/chart: transmission-0.0.8
+    helm.sh/chart: transmission-0.0.9
 spec:
   host: transmission-http
   trafficPolicy:
@@ -580,7 +581,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: transmission
     app.kubernetes.io/version: 4.0.6
-    helm.sh/chart: transmission-0.0.8
+    helm.sh/chart: transmission-0.0.9
 spec:
   instanceSelector:
     matchLabels:
@@ -602,7 +603,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: transmission
     app.kubernetes.io/version: 4.0.6
-    helm.sh/chart: transmission-0.0.8
+    helm.sh/chart: transmission-0.0.9
 spec:
   parentRefs:
     - name: shared-platform-gateway
@@ -613,17 +614,16 @@ spec:
   hostnames:
     - transmission-k8s.orhayoun.com
   rules:
-    -
+    - backendRefs:
+      - group: ""
+        kind: Service
+        name: transmission-http
+        port: 8080
+        weight: 100
       matches:
-        - path:
-            type: PathPrefix
-            value: /
-      backendRefs:
-        - group: ""
-          kind: Service
-          name: transmission-http
-          port: 8080
-          weight: 100
+      - path:
+          type: PathPrefix
+          value: /
 ---
 # Source: transmission/templates/all.yaml
 apiVersion: gateway.networking.k8s.io/v1
@@ -637,7 +637,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: transmission
     app.kubernetes.io/version: 4.0.6
-    helm.sh/chart: transmission-0.0.8
+    helm.sh/chart: transmission-0.0.9
 spec:
   parentRefs:
     - name: shared-platform-gateway
@@ -648,16 +648,15 @@ spec:
   hostnames:
     - transmission-k8s.orhayoun.com
   rules:
-    -
+    - filters:
+      - requestRedirect:
+          scheme: https
+          statusCode: 301
+        type: RequestRedirect
       matches:
-        - path:
-            type: PathPrefix
-            value: /
-      filters:
-        - requestRedirect:
-            scheme: https
-            statusCode: 301
-          type: RequestRedirect
+      - path:
+          type: PathPrefix
+          value: /
 ---
 # Source: transmission/templates/all.yaml
 apiVersion: monitoring.coreos.com/v1
@@ -671,7 +670,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: transmission
     app.kubernetes.io/version: 4.0.6
-    helm.sh/chart: transmission-0.0.8
+    helm.sh/chart: transmission-0.0.9
 spec:
   groups:
     - name: transmission.rules
@@ -848,7 +847,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: transmission
     app.kubernetes.io/version: 4.0.6
-    helm.sh/chart: transmission-0.0.8
+    helm.sh/chart: transmission-0.0.9
 spec:
   selector:
     matchLabels:

--- a/tests/snapshots/minimal.yaml
+++ b/tests/snapshots/minimal.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: transmission
     app.kubernetes.io/version: 4.0.6
-    helm.sh/chart: transmission-0.0.8
+    helm.sh/chart: transmission-0.0.9
 spec:
   podSelector:
     matchLabels:
@@ -99,7 +99,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: transmission
     app.kubernetes.io/version: 4.0.6
-    helm.sh/chart: transmission-0.0.8
+    helm.sh/chart: transmission-0.0.9
   annotations:
     app.kubernetes.io/managed-by: argocd
     description: Transmission media center service account
@@ -117,7 +117,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: transmission
     app.kubernetes.io/version: 4.0.6
-    helm.sh/chart: transmission-0.0.8
+    helm.sh/chart: transmission-0.0.9
   annotations:
     helm.sh/resource-policy: keep
 spec:
@@ -140,7 +140,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: transmission
     app.kubernetes.io/version: 4.0.6
-    helm.sh/chart: transmission-0.0.8
+    helm.sh/chart: transmission-0.0.9
   annotations:
     description: Transmission HTTP service
 spec:
@@ -166,7 +166,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: transmission
     app.kubernetes.io/version: 4.0.6
-    helm.sh/chart: transmission-0.0.8
+    helm.sh/chart: transmission-0.0.9
 spec:
   replicas: 1
   revisionHistoryLimit: 3
@@ -184,11 +184,12 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: transmission
         app.kubernetes.io/version: 4.0.6
-        helm.sh/chart: transmission-0.0.8
+        helm.sh/chart: transmission-0.0.9
         app.kubernetes.io/part-of: download-clients
         logging.kubernetes.io/component: download-clients
         logging.kubernetes.io/service: transmission
     spec:
+      
       terminationGracePeriodSeconds: 60
       securityContext:
         fsGroup: 1010

--- a/tests/snapshots/overrides.yaml
+++ b/tests/snapshots/overrides.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: transmission
     app.kubernetes.io/version: 4.0.6
-    helm.sh/chart: transmission-0.0.8
+    helm.sh/chart: transmission-0.0.9
 spec:
   podSelector:
     matchLabels:
@@ -99,7 +99,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: transmission
     app.kubernetes.io/version: 4.0.6
-    helm.sh/chart: transmission-0.0.8
+    helm.sh/chart: transmission-0.0.9
   annotations:
     app.kubernetes.io/managed-by: argocd
     description: Transmission media center service account
@@ -117,7 +117,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: transmission
     app.kubernetes.io/version: 4.0.6
-    helm.sh/chart: transmission-0.0.8
+    helm.sh/chart: transmission-0.0.9
   annotations:
     helm.sh/resource-policy: keep
 spec:
@@ -140,7 +140,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: transmission
     app.kubernetes.io/version: 4.0.6
-    helm.sh/chart: transmission-0.0.8
+    helm.sh/chart: transmission-0.0.9
   annotations:
     description: Transmission HTTP service
 spec:
@@ -166,7 +166,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: transmission
     app.kubernetes.io/version: 4.0.6
-    helm.sh/chart: transmission-0.0.8
+    helm.sh/chart: transmission-0.0.9
   annotations:
     description: Transmission metrics service
 spec:
@@ -192,7 +192,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: transmission
     app.kubernetes.io/version: 4.0.6
-    helm.sh/chart: transmission-0.0.8
+    helm.sh/chart: transmission-0.0.9
 spec:
   replicas: 2
   revisionHistoryLimit: 3
@@ -210,11 +210,12 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: transmission
         app.kubernetes.io/version: 4.0.6
-        helm.sh/chart: transmission-0.0.8
+        helm.sh/chart: transmission-0.0.9
         app.kubernetes.io/part-of: download-clients
         logging.kubernetes.io/component: download-clients
         logging.kubernetes.io/service: transmission
     spec:
+      
       terminationGracePeriodSeconds: 60
       securityContext:
         fsGroup: 2000
@@ -434,7 +435,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: transmission
     app.kubernetes.io/version: 4.0.6
-    helm.sh/chart: transmission-0.0.8
+    helm.sh/chart: transmission-0.0.9
 spec:
   selector:
     matchLabels:
@@ -463,7 +464,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: transmission
     app.kubernetes.io/version: 4.0.6
-    helm.sh/chart: transmission-0.0.8
+    helm.sh/chart: transmission-0.0.9
 spec:
   selector:
     matchLabels:
@@ -492,7 +493,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: transmission
     app.kubernetes.io/version: 4.0.6
-    helm.sh/chart: transmission-0.0.8
+    helm.sh/chart: transmission-0.0.9
 spec:
   selector:
     matchLabels:
@@ -522,7 +523,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: transmission
     app.kubernetes.io/version: 4.0.6
-    helm.sh/chart: transmission-0.0.8
+    helm.sh/chart: transmission-0.0.9
 spec:
   selector:
     matchLabels:
@@ -551,7 +552,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: transmission
     app.kubernetes.io/version: 4.0.6
-    helm.sh/chart: transmission-0.0.8
+    helm.sh/chart: transmission-0.0.9
 spec:
   host: transmission-http
   trafficPolicy:
@@ -580,7 +581,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: transmission
     app.kubernetes.io/version: 4.0.6
-    helm.sh/chart: transmission-0.0.8
+    helm.sh/chart: transmission-0.0.9
 spec:
   instanceSelector:
     matchLabels:
@@ -602,7 +603,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: transmission
     app.kubernetes.io/version: 4.0.6
-    helm.sh/chart: transmission-0.0.8
+    helm.sh/chart: transmission-0.0.9
 spec:
   parentRefs:
     - name: shared-platform-gateway
@@ -613,17 +614,16 @@ spec:
   hostnames:
     - transmission-k8s.orhayoun.com
   rules:
-    -
+    - backendRefs:
+      - group: ""
+        kind: Service
+        name: transmission-http
+        port: 8080
+        weight: 100
       matches:
-        - path:
-            type: PathPrefix
-            value: /
-      backendRefs:
-        - group: ""
-          kind: Service
-          name: transmission-http
-          port: 8080
-          weight: 100
+      - path:
+          type: PathPrefix
+          value: /
 ---
 # Source: transmission/templates/all.yaml
 apiVersion: gateway.networking.k8s.io/v1
@@ -637,7 +637,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: transmission
     app.kubernetes.io/version: 4.0.6
-    helm.sh/chart: transmission-0.0.8
+    helm.sh/chart: transmission-0.0.9
 spec:
   parentRefs:
     - name: shared-platform-gateway
@@ -648,16 +648,15 @@ spec:
   hostnames:
     - transmission-k8s.orhayoun.com
   rules:
-    -
+    - filters:
+      - requestRedirect:
+          scheme: https
+          statusCode: 301
+        type: RequestRedirect
       matches:
-        - path:
-            type: PathPrefix
-            value: /
-      filters:
-        - requestRedirect:
-            scheme: https
-            statusCode: 301
-          type: RequestRedirect
+      - path:
+          type: PathPrefix
+          value: /
 ---
 # Source: transmission/templates/all.yaml
 apiVersion: monitoring.coreos.com/v1
@@ -671,7 +670,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: transmission
     app.kubernetes.io/version: 4.0.6
-    helm.sh/chart: transmission-0.0.8
+    helm.sh/chart: transmission-0.0.9
 spec:
   groups:
     - name: transmission.rules
@@ -848,7 +847,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: transmission
     app.kubernetes.io/version: 4.0.6
-    helm.sh/chart: transmission-0.0.8
+    helm.sh/chart: transmission-0.0.9
 spec:
   selector:
     matchLabels:

--- a/tests/transmission_contract_test.yaml
+++ b/tests/transmission_contract_test.yaml
@@ -145,12 +145,13 @@ tests:
 
   - it: applies explicit transmission image override for controlled rollouts
     set:
-      deployment:
-        containers:
-          transmission:
-            image:
-              repository: registry.internal/transmission
-              tag: ci-test
+      workload:
+        spec:
+          containers:
+            transmission:
+              image:
+                repository: registry.internal/transmission
+                tag: ci-test
     asserts:
       - documentIndex: 1
         equal:

--- a/tests/transmission_workload_overrides_test.yaml
+++ b/tests/transmission_workload_overrides_test.yaml
@@ -2,10 +2,11 @@ suite: transmission workload overrides
 templates:
   - templates/all.yaml
 tests:
-  - it: applies deployment replica override
+  - it: applies workload replica override
     set:
-      deployment:
-        replicas: 2
+      workload:
+        spec:
+          replicas: 2
     asserts:
       - documentSelector:
           path: kind
@@ -16,9 +17,10 @@ tests:
 
   - it: applies pod security context fsGroup override
     set:
-      deployment:
-        podSecurityContext:
-          fsGroup: 2000
+      workload:
+        spec:
+          podSecurityContext:
+            fsGroup: 2000
     asserts:
       - documentSelector:
           path: kind

--- a/values.yaml
+++ b/values.yaml
@@ -245,243 +245,245 @@ network:
           maxEjectionPercent: 50
 
 # ----------------------------------------------------------------------------
-# Deployment Configuration
+# Workload Configuration
 # ----------------------------------------------------------------------------
-deployment:
-  replicas: 1
-  strategy:
-    type: Recreate
-  revisionHistoryLimit: 3
-  terminationGracePeriodSeconds: 60
-  dnsPolicy: ClusterFirst
-  enableServiceLinks: false
-  automountServiceAccountToken: false
+workload:
+  type: deployment
+  spec:
+    replicas: 1
+    strategy:
+      type: Recreate
+    revisionHistoryLimit: 3
+    terminationGracePeriodSeconds: 60
+    dnsPolicy: ClusterFirst
+    enableServiceLinks: false
+    automountServiceAccountToken: false
 
-  # Pod labels
-  podLabels:
-    app.kubernetes.io/part-of: download-clients
-    logging.kubernetes.io/component: download-clients
-    logging.kubernetes.io/service: transmission
+    # Pod labels
+    podLabels:
+      app.kubernetes.io/part-of: download-clients
+      logging.kubernetes.io/component: download-clients
+      logging.kubernetes.io/service: transmission
 
-  # Pod security context
-  podSecurityContext:
-    fsGroup: 1010
-    fsGroupChangePolicy: OnRootMismatch
-    runAsNonRoot: true
-    supplementalGroups: []
+    # Pod security context
+    podSecurityContext:
+      fsGroup: 1010
+      fsGroupChangePolicy: OnRootMismatch
+      runAsNonRoot: true
+      supplementalGroups: []
 
-  # Main container configuration
-  containers:
-    transmission:
-      enabled: true
-      image:
-        repository: ghcr.io/runlix/transmission
-        tag: "release-4.0.6-latest@sha256:dc5948e80732d5dbc2ce4a9ed19a07c822de6348926833798c52c63be81af747"
-        pullPolicy: IfNotPresent
+    # Main container configuration
+    containers:
+      transmission:
+        enabled: true
+        image:
+          repository: ghcr.io/runlix/transmission
+          tag: "release-4.0.6-latest@sha256:dc5948e80732d5dbc2ce4a9ed19a07c822de6348926833798c52c63be81af747"
+          pullPolicy: IfNotPresent
 
-      env:
-        - name: TZ
-          value: "UTC"
-        - name: TRANSMISSION_WEB_HOME
-          value: "/usr/share/transmission/public_html"
-        - name: USER
-          value: "admin"
-        - name: TRANSMISSION_RPC_ENABLED
-          value: "true"
-        - name: TRANSMISSION_RPC_BIND_ADDRESS
-          value: "0.0.0.0"
-        - name: TRANSMISSION_RPC_PORT
-          value: "8080"
-        - name: TRANSMISSION_RPC_WHITELIST_ENABLED
-          value: "false"
-        - name: TRANSMISSION_RPC_HOST_WHITELIST_ENABLED
-          value: "false"
-        - name: TRANSMISSION_DOWNLOAD_DIR
-          value: "/downloads/complete"
-        - name: TRANSMISSION_INCOMPLETE_DIR_ENABLED
-          value: "true"
-        - name: TRANSMISSION_INCOMPLETE_DIR
-          value: "/downloads/incomplete"
-        - name: TRANSMISSION_WATCH_DIR_ENABLED
-          value: "true"
-        - name: TRANSMISSION_WATCH_DIR
-          value: "/watch"
-        - name: TRANSMISSION_PEER_LIMIT_GLOBAL
-          value: "200"
-        - name: TRANSMISSION_PEER_LIMIT_PER_TORRENT
-          value: "50"
-        - name: TRANSMISSION_SPEED_LIMIT_UP_ENABLED
-          value: "false"
-        - name: TRANSMISSION_SPEED_LIMIT_DOWN_ENABLED
-          value: "false"
-        - name: TRANSMISSION_BLOCKLIST_ENABLED
-          value: "false"
-        - name: TRANSMISSION_DHT_ENABLED
-          value: "true"
-        - name: TRANSMISSION_PEX_ENABLED
-          value: "true"
-        - name: TRANSMISSION_LPD_ENABLED
-          value: "false"
+        env:
+          - name: TZ
+            value: "UTC"
+          - name: TRANSMISSION_WEB_HOME
+            value: "/usr/share/transmission/public_html"
+          - name: USER
+            value: "admin"
+          - name: TRANSMISSION_RPC_ENABLED
+            value: "true"
+          - name: TRANSMISSION_RPC_BIND_ADDRESS
+            value: "0.0.0.0"
+          - name: TRANSMISSION_RPC_PORT
+            value: "8080"
+          - name: TRANSMISSION_RPC_WHITELIST_ENABLED
+            value: "false"
+          - name: TRANSMISSION_RPC_HOST_WHITELIST_ENABLED
+            value: "false"
+          - name: TRANSMISSION_DOWNLOAD_DIR
+            value: "/downloads/complete"
+          - name: TRANSMISSION_INCOMPLETE_DIR_ENABLED
+            value: "true"
+          - name: TRANSMISSION_INCOMPLETE_DIR
+            value: "/downloads/incomplete"
+          - name: TRANSMISSION_WATCH_DIR_ENABLED
+            value: "true"
+          - name: TRANSMISSION_WATCH_DIR
+            value: "/watch"
+          - name: TRANSMISSION_PEER_LIMIT_GLOBAL
+            value: "200"
+          - name: TRANSMISSION_PEER_LIMIT_PER_TORRENT
+            value: "50"
+          - name: TRANSMISSION_SPEED_LIMIT_UP_ENABLED
+            value: "false"
+          - name: TRANSMISSION_SPEED_LIMIT_DOWN_ENABLED
+            value: "false"
+          - name: TRANSMISSION_BLOCKLIST_ENABLED
+            value: "false"
+          - name: TRANSMISSION_DHT_ENABLED
+            value: "true"
+          - name: TRANSMISSION_PEX_ENABLED
+            value: "true"
+          - name: TRANSMISSION_LPD_ENABLED
+            value: "false"
 
-      envFrom:
-        - secretRef:
-            name: transmission-secrets
-
-      ports:
-        - containerPort: 8080
-          name: http
-          protocol: TCP
-
-      volumeMounts:
-        - name: config
-          mountPath: /config
-        - name: downloads
-          mountPath: /downloads
-        - name: media
-          mountPath: /media
-        - name: watch
-          mountPath: /watch
-
-      # Health Probes (TCP Socket for distroless image)
-      livenessProbe:
-        tcpSocket:
-          port: http
-        failureThreshold: 3
-        initialDelaySeconds: 30
-        periodSeconds: 30
-        successThreshold: 1
-        timeoutSeconds: 10
-
-      readinessProbe:
-        tcpSocket:
-          port: http
-        failureThreshold: 3
-        initialDelaySeconds: 15
-        periodSeconds: 10
-        successThreshold: 1
-        timeoutSeconds: 10
-
-      startupProbe:
-        tcpSocket:
-          port: http
-        failureThreshold: 30
-        initialDelaySeconds: 10
-        periodSeconds: 5
-        successThreshold: 1
-        timeoutSeconds: 10
-
-      # Container Security Context
-      securityContext:
-        readOnlyRootFilesystem: true
-        runAsNonRoot: true
-        runAsUser: 1011
-        runAsGroup: 1010
-        allowPrivilegeEscalation: false
-        privileged: false
-        appArmorProfile:
-          type: RuntimeDefault
-        capabilities:
-          drop:
-            - ALL
-        seccompProfile:
-          type: RuntimeDefault
-
-      # Resources
-      resources:
-        requests:
-          cpu: 100m
-          memory: 256Mi
-          ephemeral-storage: 2Gi
-        limits:
-          cpu: 1000m
-          memory: 1Gi
-          ephemeral-storage: 2Gi
-
-    # Metrics exporter container
-    transmission-exporter:
-      enabled: true
-      image:
-        repository: metalmatze/transmission-exporter
-        tag: "0.3.0@sha256:90d6acb6d47d717015eda05b8233e65e2236cbd2d56ceaf08411bbb964412c41"
-        pullPolicy: IfNotPresent
-
-      env:
-        - name: WEB_ADDR
-          value: ":9100"
-        - name: TRANSMISSION_ADDR
-          value: "http://localhost:8080"
-        - name: TRANSMISSION_USERNAME
-          value: "admin"
-        - name: TRANSMISSION_PASSWORD
-          valueFrom:
-            secretKeyRef:
+        envFrom:
+          - secretRef:
               name: transmission-secrets
-              key: PASS
 
-      ports:
-        - containerPort: 9100
-          name: metrics
-          protocol: TCP
+        ports:
+          - containerPort: 8080
+            name: http
+            protocol: TCP
 
-      # Health Probes
-      livenessProbe:
-        httpGet:
-          path: /metrics
-          port: metrics
-          scheme: HTTP
-        initialDelaySeconds: 30
-        periodSeconds: 30
-        timeoutSeconds: 5
-        failureThreshold: 3
-        successThreshold: 1
+        volumeMounts:
+          - name: config
+            mountPath: /config
+          - name: downloads
+            mountPath: /downloads
+          - name: media
+            mountPath: /media
+          - name: watch
+            mountPath: /watch
 
-      readinessProbe:
-        httpGet:
-          path: /metrics
-          port: metrics
-          scheme: HTTP
-        initialDelaySeconds: 10
-        periodSeconds: 10
-        timeoutSeconds: 5
-        failureThreshold: 3
-        successThreshold: 1
+        # Health Probes (TCP Socket for distroless image)
+        livenessProbe:
+          tcpSocket:
+            port: http
+          failureThreshold: 3
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 10
 
-      startupProbe:
-        httpGet:
-          path: /metrics
-          port: metrics
-          scheme: HTTP
-        initialDelaySeconds: 45
-        periodSeconds: 10
-        timeoutSeconds: 10
-        failureThreshold: 30
-        successThreshold: 1
+        readinessProbe:
+          tcpSocket:
+            port: http
+          failureThreshold: 3
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 10
 
-      # Container Security Context
-      securityContext:
-        allowPrivilegeEscalation: false
-        readOnlyRootFilesystem: true
-        runAsNonRoot: true
-        runAsUser: 65534  # nobody user
-        runAsGroup: 65534
-        appArmorProfile:
-          type: RuntimeDefault
-        capabilities:
-          drop:
-            - ALL
-        seccompProfile:
-          type: RuntimeDefault
+        startupProbe:
+          tcpSocket:
+            port: http
+          failureThreshold: 30
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 10
 
-      # Resources
-      resources:
-        requests:
-          cpu: 10m
-          memory: 32Mi
-          ephemeral-storage: 100Mi
-        limits:
-          cpu: 100m
-          memory: 64Mi
-          ephemeral-storage: 100Mi
+        # Container Security Context
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1011
+          runAsGroup: 1010
+          allowPrivilegeEscalation: false
+          privileged: false
+          appArmorProfile:
+            type: RuntimeDefault
+          capabilities:
+            drop:
+              - ALL
+          seccompProfile:
+            type: RuntimeDefault
+
+        # Resources
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+            ephemeral-storage: 2Gi
+          limits:
+            cpu: 1000m
+            memory: 1Gi
+            ephemeral-storage: 2Gi
+
+      # Metrics exporter container
+      transmission-exporter:
+        enabled: true
+        image:
+          repository: metalmatze/transmission-exporter
+          tag: "0.3.0@sha256:90d6acb6d47d717015eda05b8233e65e2236cbd2d56ceaf08411bbb964412c41"
+          pullPolicy: IfNotPresent
+
+        env:
+          - name: WEB_ADDR
+            value: ":9100"
+          - name: TRANSMISSION_ADDR
+            value: "http://localhost:8080"
+          - name: TRANSMISSION_USERNAME
+            value: "admin"
+          - name: TRANSMISSION_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: transmission-secrets
+                key: PASS
+
+        ports:
+          - containerPort: 9100
+            name: metrics
+            protocol: TCP
+
+        # Health Probes
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 3
+          successThreshold: 1
+
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+          successThreshold: 1
+
+        startupProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+            scheme: HTTP
+          initialDelaySeconds: 45
+          periodSeconds: 10
+          timeoutSeconds: 10
+          failureThreshold: 30
+          successThreshold: 1
+
+        # Container Security Context
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 65534  # nobody user
+          runAsGroup: 65534
+          appArmorProfile:
+            type: RuntimeDefault
+          capabilities:
+            drop:
+              - ALL
+          seccompProfile:
+            type: RuntimeDefault
+
+        # Resources
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+            ephemeral-storage: 100Mi
+          limits:
+            cpu: 100m
+            memory: 64Mi
+            ephemeral-storage: 100Mi
 
 # ----------------------------------------------------------------------------
 # Feature: Persistence


### PR DESCRIPTION
## Summary
- migrate Transmission values, scenarios, and unit tests from top-level deployment keys to workload.type/spec
- bump lib-chart to 0.0.14 and refresh Chart.lock
- regenerate snapshots and align README dependency references

## Validation
- scripts/chart-ci.sh transmission-helm