### PR TITLE
ci: bump build-workflow to v0.1.32

### DIFF
--- a/.github/workflows/on-tag.yaml
+++ b/.github/workflows/on-tag.yaml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   publish-chart:
-    uses: orhayoun-eevee/build-workflow/.github/workflows/release-chart.yaml@v0.1.31
+    uses: orhayoun-eevee/build-workflow/.github/workflows/release-chart.yaml@v0.1.32
     with:
       chart_path: .
       release_environment: production

--- a/.github/workflows/pr-required-checks.yaml
+++ b/.github/workflows/pr-required-checks.yaml
@@ -33,7 +33,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/pr-required-checks-chart.yaml@v0.1.31
+    uses: orhayoun-eevee/build-workflow/.github/workflows/pr-required-checks-chart.yaml@v0.1.32
     with:
       chart_kind: app
     secrets:

--- a/.github/workflows/renovate-config.yaml
+++ b/.github/workflows/renovate-config.yaml
@@ -21,4 +21,4 @@ concurrency:
 
 jobs:
   validate:
-    uses: orhayoun-eevee/build-workflow/.github/workflows/renovate-config.yaml@v0.1.31
+    uses: orhayoun-eevee/build-workflow/.github/workflows/renovate-config.yaml@v0.1.32

--- a/.github/workflows/renovate-snapshot-update.yaml
+++ b/.github/workflows/renovate-snapshot-update.yaml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   update-snapshots:
     if: github.event.pull_request.head.repo.full_name == github.repository
-    uses: orhayoun-eevee/build-workflow/.github/workflows/renovate-snapshot-update.yaml@v0.1.31
+    uses: orhayoun-eevee/build-workflow/.github/workflows/renovate-snapshot-update.yaml@v0.1.32
     with:
       snapshots_dir: tests/snapshots
     secrets:


### PR DESCRIPTION
## Summary
- update shared build-workflow reusable workflow refs to v0.1.32

## Validation
- build-workflow v0.1.32 publish run passed: https://github.com/orhayoun-eevee/build-workflow/actions/runs/25635806510
- local chart CI not run because local Docker daemon is unavailable; GitHub PR checks are the validation gate.